### PR TITLE
Revise Definition of Done for clarity and scope

### DIFF
--- a/content/en/docs/workflow-management/definition-of-done.md
+++ b/content/en/docs/workflow-management/definition-of-done.md
@@ -9,26 +9,25 @@ tags: ["Workflow", "Team", "Quality"]
 
 > Is it __DONE__, __DONE DONE__, or is it __DONE DONE DONE__?
 
-All teams need a Definition of Done. The Definition of Done is an agreement made between the team
-that a unit of work isn't complete without meeting certain conditions.
+All organisations need a Definition of Done, and every team should define what Done means for the things they deliver within the context of the organisation’s Definition. The Definition of Done is a shared agreement that no unit of work is complete until it meets all agreed conditions.
 
 ## Recommended Practices
 
-We use the Definition of Done most commonly for user stories. The team and
-product owner must agree that the story has met all criteria for it to be
-considered done.
+While the Definition of Done applies to the entire product, you can test it against individual backlog items such as user stories. The whole team, including the Product Owner, must agree that each item meets all criteria before it is considered done.
 
-A definition of done can include anything a team cares about, but must include
-these criteria:
+Each organisation should create a core Definition of Done that reflects what it values, but it must include at least these criteria:
 
-- All tests passed
-- All acceptance criteria have been met
-- Code reviewed by team member and merged to trunk
-- Demoed to team/stakeholders as close to prod as possible
-- All code associated with the acceptance criteria deployed to production
+* Deployed to at least a subset of real users
+* Collecting telemetry to validate the original hypothesis
 
-Once your team has identified all criteria that a unit of work needs to be
-considered done, you must hold yourself accountable to your Definition of Done.
+Each product, and subsequently each team, should define its own criteria within those organisational boundaries. At a minimum, include the following:
+
+* All tests passed
+* Code reviewed by a team member and merged to trunk
+* Demoed to the team or stakeholders in a production-like environment
+* All code associated with the work deployed to production
+
+Once you have agreed on your Definition of Done, hold yourselves accountable to it for every unit of work.
 
 ## Value
 
@@ -39,6 +38,6 @@ be delivered to our customers.
 ## Acceptance Criteria
 
 - Identify what your team cares about as a Definition of Done.
-- Use your Definition of Done as a tool to ensure quality stories are being
+- Use your Definition of Done as a tool to ensure quality items are being
   released into production.
 - Revisit and evaluate your Definition of Done.


### PR DESCRIPTION
Updated the Definition of Done to reflect that all organisations need a Definition of Done and clarified the criteria for individual backlog items.

Main ethos changes:

 - There should be an organisational definition of done
 - Done should reflect the quality bar for the how, not the what or the why (no customer validation and no acceptance criteria)

Pulling on https://nkdagility.com/resources/definition-of-done

------

This pull request updates the documentation for the Definition of Done to clarify its scope and improve guidance for teams and organizations. The changes emphasize that the Definition of Done should be defined at both the organizational and team levels, and update recommended practices and acceptance criteria to better reflect modern workflow management.

**Definition of Done guidance:**

* Updated the explanation to state that all organizations need a Definition of Done, and that every team should define what "Done" means for their deliverables within the organization's context. The Definition of Done is now described as a shared agreement that no unit of work is complete until all agreed conditions are met.
* Clarified that the Definition of Done applies to the entire product, but can be tested against individual backlog items (e.g., user stories), and that the whole team—including the Product Owner—must agree on completion criteria.

**Criteria and practices:**

* Revised the core criteria for a Definition of Done at the organizational level to include deployment to real users and telemetry collection, and specified minimum criteria for teams and products (tests passed, code review, demo, production deployment).
* Updated acceptance criteria language to refer to "quality items" instead of "quality stories" to broaden applicability.